### PR TITLE
update dependency on pyedflib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(*names, **kwargs):
         return fh.read()
 
 
-my_req = ['numpy', 'scipy', 'pyedflib==0.1.15', 'click==7.0', 'appdirs==1.4.3', 'sentry_sdk==1.0.0']
+my_req = ['numpy', 'scipy', 'pyedflib==0.1.22', 'click==7.0', 'appdirs==1.4.3', 'sentry_sdk==1.0.0']
 ext_modules_list = []
 current_platform = sys.platform
 


### PR DESCRIPTION
https://github.com/Mentalab-hub/explorepy/blob/df7cd3224a401630ba6f276196a4dceec5c10341/setup.py#L31

Due to some requirements in the installer for `pyedflib==0.1.15` Visual Studio must be installed to compile it (on Windows).
For the most recent version of `pyedflib==0.1.22` there are wheels provided, so that requirement would not be there anymore, so I suggest updating the reqs.

As far as I'm aware there are no breaking changes since 0.1.15 (coincidentally I'm one of the maintainers of `pyedflib`). Greetings from Mannheim, we just received your Explorer and are eager to test it :) 

edit: I see VS14 / C++ compiler is needed anyway for building `explorepy`, so might not be an issue anyway and it is mentioned in the requirements. :)