### PR TITLE
Add triggers

### DIFF
--- a/src/explorepy/dashboard/dashboard.py
+++ b/src/explorepy/dashboard/dashboard.py
@@ -696,7 +696,7 @@ class Dashboard:
 
     def _init_set_marker(self):
         self.marker_button = Button(label=u"Set", button_type="default", width=80, height=31, disabled=True)
-        self.event_code_input = TextInput(value="8", title="Event code:", width=80, disabled=True)
+        self.event_code_input = TextInput(value="0", title="Event code:", width=80, disabled=True)
         self.event_code_input.on_change('value', self._check_marker_value)
         self.marker_button.on_click(self._set_marker)
         return column([Spacer(width=170, height=5),
@@ -712,10 +712,10 @@ class Dashboard:
     def _check_marker_value(self, attr, old, new):
         try:
             code = int(self.event_code_input.value)
-            if code < 7 or code > 65535:
-                raise ValueError('Value must be an integer between 8 and 65535')
+            if code < 0 or code > 65535:
+                raise ValueError('Value must be an integer between 0 and 65535')
         except ValueError:
-            self.event_code_input.value = "7<val<65535"
+            self.event_code_input.value = "0<=val<=65535"
 
     @gen.coroutine
     @without_property_validation

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -331,8 +331,7 @@ class Explore:
         """Sets a digital event marker while streaming
 
         Args:
-            code (int): Marker code. It must be an integer larger than 7
-                        (codes from 0 to 7 are reserved for hardware markers).
+            code (int): Marker code (must be in range of 0-65535)
 
         """
         self._check_connection()

--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -2,6 +2,7 @@
 """This module contains all packet classes of Mentalab Explore device"""
 import abc
 import logging
+import struct
 from enum import IntEnum
 
 import numpy as np
@@ -393,6 +394,20 @@ class SoftwareMarker(EventMarker):
     def _convert(self, bin_data):
         self.code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
 
+    @staticmethod
+    def create(local_time, code):
+        """ Create a software marker
+
+        Args:
+            local_time (double): Local time from LSL
+            code (int): Event marker code
+
+        Returns:
+            SoftwareMarker
+        """
+        return SoftwareMarker(local_time * TIMESTAMP_SCALE,
+                              payload=bytearray(struct.pack('<H', code) + b'\xaf\xbe\xad\xde')
+                              )
 
 class TriggerIn(EventMarker):
     """Trigger in packet"""

--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -354,6 +354,7 @@ class EventMarker(Packet):
     def __init__(self, timestamp, payload, time_offset=0):
         super().__init__(timestamp, payload, time_offset)
         self.code = None
+        self._label_prefix = None
 
     @abc.abstractmethod
     def _convert(self, bin_data):
@@ -367,7 +368,7 @@ class EventMarker(Packet):
         """Get marker data
         Args:
             srate: NOT USED. Only for compatibility purpose"""
-        return [self.timestamp], [self.code]
+        return [self.timestamp], [self._label_prefix + str(self.code)]
 
     def __str__(self):
         return f"{self.__class__.__name__}, Timestamp: {self.timestamp}, Code: {self.code}"
@@ -379,6 +380,7 @@ class PushButtonMarker(EventMarker):
         super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
+        self._label_prefix = 'pb_'
 
     def _convert(self, bin_data):
         self.code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
@@ -390,6 +392,7 @@ class SoftwareMarker(EventMarker):
         super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
+        self._label_prefix = 'sw_'
 
     def _convert(self, bin_data):
         self.code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
@@ -417,6 +420,7 @@ class TriggerIn(EventMarker):
         self._time_offset = time_offset
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
+        self._label_prefix = 'in_'
 
     def _convert(self, bin_data):
         precise_ts = np.asscalar(np.frombuffer(bin_data,
@@ -437,6 +441,7 @@ class TriggerOut(EventMarker):
         self._time_offset = time_offset
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
+        self._label_prefix = 'out_'
 
     def _convert(self, bin_data):
         precise_ts = np.asscalar(np.frombuffer(bin_data,

--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -409,6 +409,7 @@ class SoftwareMarker(EventMarker):
                               payload=bytearray(struct.pack('<H', code) + b'\xaf\xbe\xad\xde')
                               )
 
+
 class TriggerIn(EventMarker):
     """Trigger in packet"""
     def __init__(self, timestamp, payload, time_offset=0):

--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -52,7 +52,7 @@ class Packet:
             time_offset (double): Time offset defined by parser. It will be the timestamp of the first packet when
                                     streaming in realtime. It will be zero while converting a binary file.
         """
-        self.timestamp = timestamp /TIMESTAMP_SCALE + time_offset
+        self.timestamp = timestamp / TIMESTAMP_SCALE + time_offset
 
     @abc.abstractmethod
     def _convert(self, bin_data):

--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -11,6 +11,8 @@ from explorepy._exceptions import FletcherError
 
 logger = logging.getLogger(__name__)
 
+TIMESTAMP_SCALE = 10000
+
 
 class PACKET_ID(IntEnum):
     """Packet ID enum"""
@@ -27,8 +29,10 @@ class PACKET_ID(IntEnum):
     EEG98R = 210
     CMDRCV = 192
     CMDSTAT = 193
-    MARKER = 194
+    PUSHMARKER = 194
     CALIBINFO = 195
+    TRIGGER_OUT = 177  # Trigger-out of Explore device
+    TRIGGER_IN = 178   # Trigger-in to Explore device
 
 
 EXG_UNIT = 1e-6
@@ -38,13 +42,16 @@ class Packet:
     """An abstract base class for Explore packet"""
     __metadata__ = abc.ABCMeta
 
-    def __init__(self, timestamp, payload):
+    def __init__(self, timestamp, payload, time_offset=0):
         """Gets the timestamp and payload and initializes the packet object
 
         Args:
-            payload (bytearray): a byte array including binary data and fletcher
+            timestamp (double): Raw timestamp of the packet
+            payload (bytearray): A byte array including binary data and fletcher
+            time_offset (double): Time offset defined by parser. It will be the timestamp of the first packet when
+                                    streaming in realtime. It will be zero while converting a binary file.
         """
-        self.timestamp = timestamp
+        self.timestamp = timestamp /TIMESTAMP_SCALE + time_offset
 
     @abc.abstractmethod
     def _convert(self, bin_data):
@@ -77,6 +84,11 @@ class Packet:
 class EEG(Packet):
     """EEG packet class"""
     __metadata__ = abc.ABCMeta
+
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
+        self.data = None
+        self.imp_data = None
 
     def calculate_impedance(self, imp_calib_info):
         """calculate impedance with the help of impedance calibration info
@@ -112,11 +124,20 @@ class EEG(Packet):
         """Get peak to peak value"""
         return np.ptp(self.data, axis=1)
 
+    def __str__(self):
+        pass
+
+    def _check_fletcher(self, fletcher):
+        pass
+
+    def _convert(self, bin_data):
+        pass
+
 
 class EEG94(EEG):
     """EEG packet for 4 channel device"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -140,8 +161,8 @@ class EEG94(EEG):
 
 class EEG98(EEG):
     """EEG packet for 8 channel device"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -165,8 +186,8 @@ class EEG98(EEG):
 
 class EEG99s(EEG):
     """EEG packet for 8 channel device"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -190,8 +211,8 @@ class EEG99s(EEG):
 
 class EEG99(EEG):
     """EEG packet for 8 channel device"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -214,8 +235,8 @@ class EEG99(EEG):
 
 class Orientation(Packet):
     """Orientation data packet"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
         self.theta = None
@@ -255,8 +276,8 @@ class Orientation(Packet):
 
 class Environment(Packet):
     """Environment data packet"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -308,8 +329,8 @@ class Environment(Packet):
 
 class TimeStamp(Packet):
     """Time stamp data packet"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
         self.raw_data = None
@@ -326,33 +347,104 @@ class TimeStamp(Packet):
 
 
 class EventMarker(Packet):
-    """Marker packet"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
-        self._convert(payload[:-4])
-        self._check_fletcher(payload[-4:])
+    """Abstract class for event markers"""
+    __metadata__ = abc.ABCMeta
 
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
+        self.code = None
+
+    @abc.abstractmethod
     def _convert(self, bin_data):
-        self.marker_code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
+        pass
 
     def _check_fletcher(self, fletcher):
         if not fletcher == b'\xaf\xbe\xad\xde':
             raise FletcherError('Fletcher value is incorrect!')
 
-    def __str__(self):
-        return "Event marker: " + str(self.marker_code)
-
     def get_data(self, srate=None):
         """Get marker data
         Args:
             srate: NOT USED. Only for compatibility purpose"""
-        return [self.timestamp], [self.marker_code]
+        return [self.timestamp], [self.code]
+
+    def __str__(self):
+        return f"{self.__class__.__name__}, Timestamp: {self.timestamp}, Code: {self.code}"
+
+
+class PushButtonMarker(EventMarker):
+    """Push Button Marker packet"""
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
+        self._convert(payload[:-4])
+        self._check_fletcher(payload[-4:])
+
+    def _convert(self, bin_data):
+        self.code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
+
+
+class SoftwareMarker(EventMarker):
+    """Software marker packet"""
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
+        self._convert(payload[:-4])
+        self._check_fletcher(payload[-4:])
+
+    def _convert(self, bin_data):
+        self.code = np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'))[0]
+
+
+class TriggerIn(EventMarker):
+    """Trigger in packet"""
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(TriggerIn, self).__init__(timestamp, payload, time_offset)
+        self._time_offset = time_offset
+        self._convert(payload[:-4])
+        self._check_fletcher(payload[-4:])
+
+    def _convert(self, bin_data):
+        precise_ts = np.asscalar(np.frombuffer(bin_data,
+                                               dtype=np.dtype(np.uint32).newbyteorder('<'),
+                                               count=1,
+                                               offset=0))
+        self.timestamp = precise_ts / TIMESTAMP_SCALE + self._time_offset
+        code = np.asscalar(np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'), count=1, offset=4))
+        self.code = code
+        mac_address = hex(int(np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'), count=1, offset=6)))
+        self.mac_address = mac_address
+
+
+class TriggerOut(EventMarker):
+    """Trigger-out packet"""
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(TriggerOut, self).__init__(timestamp, payload, time_offset)
+        self._time_offset = time_offset
+        self._convert(payload[:-4])
+        self._check_fletcher(payload[-4:])
+
+    def _convert(self, bin_data):
+        precise_ts = np.asscalar(np.frombuffer(bin_data,
+                                               dtype=np.dtype(np.uint32).newbyteorder('<'),
+                                               count=1,
+                                               offset=0))
+
+        self.timestamp = precise_ts / TIMESTAMP_SCALE + self._time_offset
+        code = np.asscalar(np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'), count=1, offset=4))
+        """
+        if label == 240:
+            label = "Sync"
+        if label == 15:
+            label = "ADS_Start"
+        """
+        self.code = code
+        mac_address = hex(int(np.frombuffer(bin_data, dtype=np.dtype(np.uint16).newbyteorder('<'), count=1, offset=6)))
+        self.mac_address = mac_address
 
 
 class Disconnect(Packet):
     """Disconnect packet"""
-    def __init__(self, timestamp, payload):
-        super().__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super().__init__(timestamp, payload, time_offset)
         self._check_fletcher(payload)
 
     def _convert(self, bin_data):
@@ -368,8 +460,8 @@ class Disconnect(Packet):
 
 class DeviceInfo(Packet):
     """Device information packet"""
-    def __init__(self, timestamp, payload):
-        super(DeviceInfo, self).__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(DeviceInfo, self).__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -400,8 +492,8 @@ class DeviceInfo(Packet):
 
 class CommandRCV(Packet):
     """Command Status packet"""
-    def __init__(self, timestamp, payload):
-        super(CommandRCV, self).__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(CommandRCV, self).__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -418,8 +510,8 @@ class CommandRCV(Packet):
 
 class CommandStatus(Packet):
     """Command Status packet"""
-    def __init__(self, timestamp, payload):
-        super(CommandStatus, self).__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(CommandStatus, self).__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -437,8 +529,8 @@ class CommandStatus(Packet):
 
 class CalibrationInfo(Packet):
     """Calibration Info packet"""
-    def __init__(self, timestamp, payload):
-        super(CalibrationInfo, self).__init__(timestamp, payload)
+    def __init__(self, timestamp, payload, time_offset=0):
+        super(CalibrationInfo, self).__init__(timestamp, payload, time_offset)
         self._convert(payload[:-4])
         self._check_fletcher(payload[-4:])
 
@@ -476,5 +568,7 @@ PACKET_CLASS_DICT = {
     PACKET_ID.CMDRCV: CommandRCV,
     PACKET_ID.CMDSTAT: CommandStatus,
     PACKET_ID.CALIBINFO: CalibrationInfo,
-    PACKET_ID.MARKER: EventMarker
+    PACKET_ID.PUSHMARKER: PushButtonMarker,
+    PACKET_ID.TRIGGER_IN: TriggerIn,
+    PACKET_ID.TRIGGER_OUT: TriggerOut
 }

--- a/src/explorepy/parser.py
+++ b/src/explorepy/parser.py
@@ -9,14 +9,13 @@ import explorepy
 from explorepy._exceptions import FletcherError
 from explorepy.packet import (
     PACKET_CLASS_DICT,
+    TIMESTAMP_SCALE,
     DeviceInfo
 )
 from explorepy.tools import get_local_time
 
 
 logger = logging.getLogger(__name__)
-
-TIMESTAMP_SCALE = 10000
 
 
 class Parser:
@@ -142,31 +141,27 @@ class Parser:
         if self._time_offset is None:
             self._time_offset = get_local_time() - timestamp / TIMESTAMP_SCALE
             timestamp = 0
-        else:
-            timestamp = timestamp / TIMESTAMP_SCALE + self._time_offset
 
         payload_data = self.stream_interface.read(payload - 4)
         packet = self._parse_packet(pid, timestamp, payload_data)
         return packet
 
-    @staticmethod
-    def _parse_packet(pid, timestamp, bin_data):
+    def _parse_packet(self, pid, timestamp, bin_data):
         """Generates the packets according to the pid
 
         Args:
             pid (int): Packet ID
             timestamp (int): Timestamp
-            bin_data: Binary dat
+            bin_data: Binary data
 
         Returns:
             Packet
         """
 
         if pid in PACKET_CLASS_DICT:
-            packet = PACKET_CLASS_DICT[pid](timestamp, bin_data)
+            packet = PACKET_CLASS_DICT[pid](timestamp, bin_data, self._time_offset)
         else:
             logger.debug("Unknown Packet ID:" + str(pid))
-            # raise ValueError("Unknown Packet ID:" + str(pid))
             packet = None
         return packet
 

--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -3,7 +3,6 @@
 This module is responsible for processing incoming stream from Explore device and publishing data to subscribers.
 """
 import logging
-import struct
 import time
 from enum import Enum
 
@@ -233,11 +232,10 @@ class StreamProcessor:
         logger.info(f"Setting a software marker with code: {code}")
         if not isinstance(code, int):
             raise TypeError('Marker code must be an integer!')
-        if 0 <= code <= 65535:
+        if 0 < code < 65535:
             raise ValueError('Marker code value is not valid! Code must be in range of 0-65535.')
 
-        self.process(SoftwareMarker(timestamp=get_local_time(),
-                                    payload=bytearray(struct.pack('<H', code) + b'\xaf\xbe\xad\xde')))
+        self.process(SoftwareMarker.create(get_local_time(), code))
 
     def compare_device_info(self, new_device_info):
         """Compare a device info dict with the current version

--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -21,7 +21,8 @@ from explorepy.packet import (
     DeviceInfo,
     Environment,
     EventMarker,
-    Orientation
+    Orientation,
+    SoftwareMarker
 )
 from explorepy.parser import Parser
 from explorepy.tools import (
@@ -229,14 +230,14 @@ class StreamProcessor:
 
     def set_marker(self, code):
         """Set a marker in the stream"""
-        logger.info(f"Setting a marker with code: {code}")
+        logger.info(f"Setting a software marker with code: {code}")
         if not isinstance(code, int):
             raise TypeError('Marker code must be an integer!')
-        if 0 <= code <= 7:
-            raise ValueError('Marker code value is not valid')
+        if 0 <= code <= 65535:
+            raise ValueError('Marker code value is not valid! Code must be in range of 0-65535.')
 
-        self.process(EventMarker(timestamp=get_local_time(),
-                                 payload=bytearray(struct.pack('<H', code) + b'\xaf\xbe\xad\xde')))
+        self.process(SoftwareMarker(timestamp=get_local_time(),
+                                    payload=bytearray(struct.pack('<H', code) + b'\xaf\xbe\xad\xde')))
 
     def compare_device_info(self, new_device_info):
         """Compare a device info dict with the current version

--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -232,7 +232,7 @@ class StreamProcessor:
         logger.info(f"Setting a software marker with code: {code}")
         if not isinstance(code, int):
             raise TypeError('Marker code must be an integer!')
-        if 0 < code < 65535:
+        if not 0 <= code <= 65535:
             raise ValueError('Marker code value is not valid! Code must be in range of 0-65535.')
 
         self.process(SoftwareMarker.create(get_local_time(), code))

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -493,6 +493,7 @@ class FileRecorder:
         if self.file_type == 'csv':
             data = timestamp + code
             self._csv_obj.writerow(data)
+            self._file_obj.flush()
         elif self.file_type == 'edf':
             if self._rec_time_offset is None:
                 self._rec_time_offset = timestamp[0]

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -540,7 +540,7 @@ class LslServer:
                                  type='Markers',
                                  channel_count=1,
                                  nominal_srate=0,
-                                 channel_format='int32',
+                                 channel_format='string',
                                  source_id=device_info["device_name"] + "_Markers")
 
         logger.info(

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -488,14 +488,16 @@ class FileRecorder:
             packet (explorepy.packet.EventMarker): Event marker packet
 
         """
+        timestamp, code = packet.get_data()
+        timestamp[0] = round(timestamp[0], 4)
         if self.file_type == 'csv':
-            self.write_data(packet=packet)
+            data = timestamp + code
+            self._csv_obj.writerow(data)
         elif self.file_type == 'edf':
-            timestamp, code = packet.get_data()
             if self._rec_time_offset is None:
                 self._rec_time_offset = timestamp[0]
             timestamp = timestamp - np.float64(self._rec_time_offset)
-            self._file_obj.writeAnnotation(timestamp[0], 0.001, str(int(code[0])))
+            self._file_obj.writeAnnotation(timestamp[0], 0.001, code[0])
 
 
 class LslServer:


### PR DESCRIPTION
This PR introduces Trigger-in and Trigger-out packets into Explorepy. These changes enable users to visualize triggers in the dashboard. In order to reduce complexity and avoid confusion, the event marker code range is 0-65535 for software marker, trigger-in and trigger-out markers. The push button markers' code range is still 0-7 due to FW limitations.

The recorder module has been updated as well and the markers are saved with `<PREFIX>_<CODE>` pattern. For example, a push button event is written as `pb_0` to `pb_7`. 

<html>
<body>
<!--StartFragment-->

Event marker type | Code range (in packet) | label
-- | -- | --
Push button | 0-7 | pb_#CODE
Software marker | 0-65535 | sw_#CODE
Trigger-in | 0-65535 | in_#CODE
Trigger-out | 0-65535 | out_#CODE

<!--EndFragment-->
</body>
</html>

**Tests**:
- Testing trigger-in and trigger-out (requires the new PCB).
- Test functionality of software and push button marker with the old PCBs to make sure the API is backward compatible.
- Make sure all marker events are visible in the CSV and EDF and also in LSL streams.