### PR TITLE
Save meta data

### DIFF
--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -158,6 +158,9 @@ class Explore:
         self.stream_processor.subscribe(callback=self.recorders['orn'].write_data, topic=TOPICS.raw_orn)
         self.stream_processor.subscribe(callback=self.recorders['marker'].set_marker, topic=TOPICS.marker)
         logger.info("Recording...")
+        self.recorders['meta'].write_meta()
+        self.recorders['meta'].stop()
+
         self.recorders['timer'] = Timer(duration, self.stop_recording)
 
         self.recorders['timer'].start()
@@ -184,8 +187,6 @@ class Explore:
             if self.recorders['timer'].is_alive():
                 self.recorders['timer'].cancel()
 
-            self.recorders['meta'].write_meta()
-            self.recorders['meta'].stop()
             self.recorders = {}
             logger.info('Recording stopped.')
         else:
@@ -239,6 +240,8 @@ class Explore:
         self.stream_processor.subscribe(callback=self.recorders['exg'].write_data, topic=TOPICS.raw_ExG)
         self.stream_processor.subscribe(callback=self.recorders['orn'].write_data, topic=TOPICS.raw_orn)
         self.stream_processor.subscribe(callback=self.recorders['marker'].set_marker, topic=TOPICS.marker)
+        self.recorders['meta'].write_meta()
+        self.recorders['meta'].stop()
 
         def device_info_callback(packet):
             new_device_info = packet.get_info()
@@ -254,8 +257,15 @@ class Explore:
                                                             adc_mask=self.stream_processor.device_info['adc_mask'],
                                                             do_overwrite=do_overwrite)
                 self.recorders['marker'] = self.recorders['exg']
+                self.recorders['meta'] = create_meta_recorder(filename=meta_out_file,
+                                                              fs=self.stream_processor.device_info['sampling_rate'],
+                                                              adc_mask=self.stream_processor.device_info['adc_mask'],
+                                                              device_name=self.device_name,
+                                                              do_overwrite=do_overwrite)
                 self.stream_processor.subscribe(callback=self.recorders['exg'].write_data, topic=TOPICS.raw_ExG)
                 self.stream_processor.subscribe(callback=self.recorders['marker'].set_marker, topic=TOPICS.marker)
+                self.recorders['meta'].write_meta()
+                self.recorders['meta'].stop()
 
         self.stream_processor.subscribe(callback=device_info_callback, topic=TOPICS.device_info)
         self.stream_processor.open_file(bin_file=bin_file)

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -40,8 +40,8 @@ from explorepy.tools import (
     PhysicalOrientation,
     create_exg_recorder,
     create_marker_recorder,
-    create_orn_recorder,
-    create_meta_recorder
+    create_meta_recorder,
+    create_orn_recorder
 )
 
 

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -247,6 +247,7 @@ class Explore:
             new_device_info = packet.get_info()
             if not self.stream_processor.compare_device_info(new_device_info):
                 new_file_name = exg_out_file + "_" + str(np.round(packet.timestamp, 0))
+                new_meta_name = meta_out_file + "_" + str(np.round(packet.timestamp, 0))
                 logger.warning("Creating a new file: " + new_file_name + '.' + self.recorders['file_type'])
                 self.stream_processor.unsubscribe(callback=self.recorders['exg'].write_data, topic=TOPICS.raw_ExG)
                 self.stream_processor.unsubscribe(callback=self.recorders['marker'].set_marker, topic=TOPICS.marker)
@@ -257,7 +258,7 @@ class Explore:
                                                             adc_mask=self.stream_processor.device_info['adc_mask'],
                                                             do_overwrite=do_overwrite)
                 self.recorders['marker'] = self.recorders['exg']
-                self.recorders['meta'] = create_meta_recorder(filename=meta_out_file,
+                self.recorders['meta'] = create_meta_recorder(filename=new_meta_name,
                                                               fs=self.stream_processor.device_info['sampling_rate'],
                                                               adc_mask=self.stream_processor.device_info['adc_mask'],
                                                               device_name=self.device_name,

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -212,6 +212,8 @@ class Explore:
         exg_out_file = out_full_path + filename + '_exg'
         orn_out_file = out_full_path + filename + '_orn'
         marker_out_file = out_full_path + filename + '_marker'
+        meta_out_file = out_full_path + filename + '_meta'
+
         self.stream_processor = StreamProcessor()
         self.stream_processor.read_device_info(bin_file=bin_file)
         self.recorders['exg'] = create_exg_recorder(filename=exg_out_file,
@@ -227,6 +229,12 @@ class Explore:
             self.recorders['marker'] = create_marker_recorder(filename=marker_out_file, do_overwrite=do_overwrite)
         else:
             self.recorders['marker'] = self.recorders['exg']
+
+        self.recorders['meta'] = create_meta_recorder(filename=meta_out_file,
+                                                      fs=self.stream_processor.device_info['sampling_rate'],
+                                                      adc_mask=self.stream_processor.device_info['adc_mask'],
+                                                      device_name=self.device_name,
+                                                      do_overwrite=do_overwrite)
 
         self.stream_processor.subscribe(callback=self.recorders['exg'].write_data, topic=TOPICS.raw_ExG)
         self.stream_processor.subscribe(callback=self.recorders['orn'].write_data, topic=TOPICS.raw_orn)

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -136,6 +136,24 @@ def create_marker_recorder(filename, do_overwrite):
                         file_type='csv', do_overwrite=do_overwrite)
 
 
+def create_meta_recorder(filename, fs, adc_mask, device_name, do_overwrite):
+    """ Create meta file recorder
+
+    Args:
+        filename (str): file name
+        fs (int): sampling rate
+        adc_mask (str): channel mask
+        device_name (str): device name
+        do_overwrite (str): overwrite if the file already exists
+
+    Returns:
+        FileRecorder: file recorder object
+    """
+    header = ['Device', 'sr', 'adcMask']
+    return FileRecorder(filename=filename, file_type='csv', ch_label=header, fs=fs, ch_unit=[],
+                        adc_mask=adc_mask, device_name=device_name, do_overwrite=do_overwrite)
+
+
 class HeartRateEstimator:
     def __init__(self, fs=250, smoothing_win=20):
         """Real-time heart Rate Estimator class This class provides the tools for heart rate estimation. It basically detects
@@ -357,7 +375,7 @@ class FileRecorder:
 
     """
 
-    def __init__(self, filename, ch_label, fs, ch_unit, ch_min=None, ch_max=None,
+    def __init__(self, filename, ch_label, fs, ch_unit, adc_mask=None, ch_min=None, ch_max=None,
                  device_name='Explore', file_type='edf', do_overwrite=False):
         """
 
@@ -366,6 +384,7 @@ class FileRecorder:
             ch_label (list): List of channel labels.
             fs (int): Sampling rate (must be identical for all channels)
             ch_unit (list): List of channels unit (e.g. 'uV', 'mG', 's', etc.)
+            adc_mask (str): Channel mask
             ch_min (list): List of minimum value of each channel. Only needed in edf mode (can be None in csv mode)
             ch_max (list): List of maximum value of each channel. Only needed in edf mode (can be None in csv mode)
             device_name (str): Recording device name
@@ -381,6 +400,7 @@ class FileRecorder:
         self.file_type = file_type
         self._ch_label = ch_label
         self._ch_unit = ch_unit
+        self.adc_mask = adc_mask
         self._ch_max = ch_max
         self._ch_min = ch_min
         self._n_chan = len(ch_label)
@@ -496,6 +516,11 @@ class FileRecorder:
                 self._rec_time_offset = timestamp[0]
             timestamp = timestamp - np.float64(self._rec_time_offset)
             self._file_obj.writeAnnotation(timestamp[0], 0.001, str(int(code[0])))
+
+    def write_meta(self):
+        """Writes meta data in the file"""
+        self._csv_obj.writerow([self._device_name, self._fs, self.adc_mask])
+        self._file_obj.flush()
 
 
 class LslServer:

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -150,7 +150,9 @@ def create_meta_recorder(filename, fs, adc_mask, device_name, do_overwrite):
         FileRecorder: file recorder object
     """
     header = ['Timestamp', 'Device', 'sr', 'adcMask', 'ExGUnits']
-    exg_unit = EXG_UNITS[0] # we only need the first channel's units as this will correspond with the rest
+    exg_unit = 'mV'
+    if EXG_UNITS:
+        exg_unit = EXG_UNITS[0]  # we only need the first channel's units as this will correspond with the rest
     return FileRecorder(filename=filename, file_type='csv', ch_label=header, fs=fs, ch_unit=exg_unit,
                         adc_mask=adc_mask, device_name=device_name, do_overwrite=do_overwrite)
 

--- a/src/explorepy/tools.py
+++ b/src/explorepy/tools.py
@@ -149,8 +149,9 @@ def create_meta_recorder(filename, fs, adc_mask, device_name, do_overwrite):
     Returns:
         FileRecorder: file recorder object
     """
-    header = ['Device', 'sr', 'adcMask']
-    return FileRecorder(filename=filename, file_type='csv', ch_label=header, fs=fs, ch_unit=[],
+    header = ['Timestamp', 'Device', 'sr', 'adcMask', 'ExGUnits']
+    exg_unit = EXG_UNITS[0] # we only need the first channel's units as this will correspond with the rest
+    return FileRecorder(filename=filename, file_type='csv', ch_label=header, fs=fs, ch_unit=exg_unit,
                         adc_mask=adc_mask, device_name=device_name, do_overwrite=do_overwrite)
 
 
@@ -375,7 +376,7 @@ class FileRecorder:
 
     """
 
-    def __init__(self, filename, ch_label, fs, ch_unit, adc_mask=None, ch_min=None, ch_max=None,
+    def __init__(self, filename, ch_label, fs, ch_unit, timestamp=None, adc_mask=None, ch_min=None, ch_max=None,
                  device_name='Explore', file_type='edf', do_overwrite=False):
         """
 
@@ -384,6 +385,7 @@ class FileRecorder:
             ch_label (list): List of channel labels.
             fs (int): Sampling rate (must be identical for all channels)
             ch_unit (list): List of channels unit (e.g. 'uV', 'mG', 's', etc.)
+            timestamp (datetime): The time at which this recording starts
             adc_mask (str): Channel mask
             ch_min (list): List of minimum value of each channel. Only needed in edf mode (can be None in csv mode)
             ch_max (list): List of maximum value of each channel. Only needed in edf mode (can be None in csv mode)
@@ -398,6 +400,7 @@ class FileRecorder:
 
         self._file_obj = None
         self.file_type = file_type
+        self.timestamp = timestamp
         self._ch_label = ch_label
         self._ch_unit = ch_unit
         self.adc_mask = adc_mask
@@ -519,7 +522,8 @@ class FileRecorder:
 
     def write_meta(self):
         """Writes meta data in the file"""
-        self._csv_obj.writerow([self._device_name, self._fs, self.adc_mask])
+        channels = ['ch' + str(i) for i, flag in enumerate(reversed(self.adc_mask)) if flag == 1]
+        self._csv_obj.writerow([self.timestamp, self._device_name, self._fs, str(' '.join(channels)), self._ch_unit])
         self._file_obj.flush()
 
 


### PR DESCRIPTION
On record create a new file called FILENAME_Meta, which contains meta data on the recording. Of the form:

```
Timestamp,Device,sr,adcMask,ExGUnits
TIMESTAMP,Explore_CA26,250,ch0 ch1 ch2 ch3,uV
```

Decided to populate the file only after all other recordings have gracefully exited so that the meta file exits only if the recordings were successful.