### PR TITLE
jinja import bugfix with bokeh version update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def read(*names, **kwargs):
         return fh.read()
 
 
-my_req = ['numpy', 'scipy', 'pyedflib==0.1.25', 'click==7.0', 'appdirs==1.4.3', 'sentry_sdk==1.0.0']
+my_req = ['numpy', 'scipy', 'pyedflib==0.1.25', 'click==7.1.2', 'appdirs==1.4.3', 'sentry_sdk==1.0.0']
 
 test_requirements = ["pytest==6.2.5",
                      "flake8==4.0.1",
@@ -44,7 +44,8 @@ current_platform = sys.platform
 
 if not os.environ.get('READTHEDOCS'):
     my_req.append('pylsl')
-    my_req.append('bokeh==2.4.3')
+    my_req.append('Jinja2==3.0.0')
+    my_req.append('bokeh==2.2.3')
     libPath = "lib"
     if current_platform == 'win32' or current_platform == 'win64':
         windows_lib_path = os.path.join(libPath, 'windows')

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ current_platform = sys.platform
 
 if not os.environ.get('READTHEDOCS'):
     my_req.append('pylsl')
-    my_req.append('bokeh==2.2.3')
+    my_req.append('bokeh==2.4.3')
     libPath = "lib"
     if current_platform == 'win32' or current_platform == 'win64':
         windows_lib_path = os.path.join(libPath, 'windows')


### PR DESCRIPTION
Bugfix for:
File "/home/ss/anaconda3/envs/pr-test-master/lib/python3.8/site-packages/bokeh/core/templates.py", line 42, in <module>
    from jinja2 import Environment, FileSystemLoader, Markup
ImportError: cannot import name 'Markup' from 'jinja2'

Test:
Run visualize command and verify that the dashboard is operating as before. Some things might break as the Bokeh version is updated to latest one. 