### PR TITLE
Apis 1081 explore desktop freezes when device is turned off during streaming

### DIFF
--- a/src/explorepy/btcpp.py
+++ b/src/explorepy/btcpp.py
@@ -278,6 +278,7 @@ class BLEClient(BTClient):
             if not self.is_connected:
                 break
             if self.try_disconnect.is_set():
+                await asyncio.sleep(1.0) # wait a second to give bleak time to disconnect (?)
                 logger.info("scanning for device")
                 self.ble_device = await BleakScanner.find_device_by_name(self.device_name, timeout=3)
 
@@ -288,8 +289,7 @@ class BLEClient(BTClient):
                     loop = asyncio.get_running_loop()
                     disconnect_task = loop.create_task(self.client.disconnect())
                     await disconnect_task
-                self.connection_attempt_counter = 0
-            if self.ble_device and self.client and sys.platform != 'darwin':
+            if self.ble_device and self.client and sys.platform == 'win32':
                 available_services = self.client.services  # This freezes on Mac
                 eeg_service_available = False
                 for s in available_services:

--- a/src/explorepy/btcpp.py
+++ b/src/explorepy/btcpp.py
@@ -10,6 +10,7 @@ import threading
 import time
 from queue import Queue
 
+import bleak.uuids
 from bleak import (
     BleakClient,
     BleakScanner
@@ -259,9 +260,9 @@ class BLEClient(BTClient):
 
         self.client = None
         self.ble_device = None
-        self.eeg_service_uuid = "FFFE0001-B5A3-F393-E0A9-E50E24DCCA9E"
-        self.eeg_tx_char_uuid = "FFFE0003-B5A3-F393-E0A9-E50E24DCCA9E"
-        self.eeg_rx_char_uuid = "FFFE0002-B5A3-F393-E0A9-E50E24DCCA9E"
+        self.eeg_service_uuid = bleak.uuids.normalize_uuid_str("FFFE0001-B5A3-F393-E0A9-E50E24DCCA9E")
+        self.eeg_tx_char_uuid = bleak.uuids.normalize_uuid_str("FFFE0003-B5A3-F393-E0A9-E50E24DCCA9E")
+        self.eeg_rx_char_uuid = bleak.uuids.normalize_uuid_str("FFFE0002-B5A3-F393-E0A9-E50E24DCCA9E")
         self.rx_char = None
         self.buffer = Queue()
         self.try_disconnect = asyncio.Event()
@@ -278,7 +279,7 @@ class BLEClient(BTClient):
             if not self.is_connected:
                 break
             if self.try_disconnect.is_set():
-                await asyncio.sleep(1.0) # wait a second to give bleak time to disconnect (?)
+                await asyncio.sleep(1.0)  # wait a second to give bleak time to disconnect (?)
                 logger.info("scanning for device")
                 self.ble_device = await BleakScanner.find_device_by_name(self.device_name, timeout=3)
 

--- a/src/explorepy/btcpp.py
+++ b/src/explorepy/btcpp.py
@@ -283,16 +283,11 @@ class BLEClient(BTClient):
 
                 if self.ble_device is None:
                     logger.info("no device found, wait then scan again")
-                    await asyncio.sleep(1)
-                    if self.connection_attempt_counter < 2:
-                        self.connection_attempt_counter += 1
-                        continue
-                    else:
-                        self.did_reconnection_fail.set()
-                        logger.info("ExplorePy initiating disconnection")
-                        loop = asyncio.get_running_loop()
-                        disconnect_task = loop.create_task(self.client.disconnect())
-                        await disconnect_task
+                    self.did_reconnection_fail.set()
+                    logger.info("ExplorePy initiating disconnection")
+                    loop = asyncio.get_running_loop()
+                    disconnect_task = loop.create_task(self.client.disconnect())
+                    await disconnect_task
                 self.connection_attempt_counter = 0
             if self.ble_device and self.client:
                 available_services = self.client.services

--- a/src/explorepy/btcpp.py
+++ b/src/explorepy/btcpp.py
@@ -289,8 +289,8 @@ class BLEClient(BTClient):
                     disconnect_task = loop.create_task(self.client.disconnect())
                     await disconnect_task
                 self.connection_attempt_counter = 0
-            if self.ble_device and self.client:
-                available_services = self.client.services
+            if self.ble_device and self.client and sys.platform != 'darwin':
+                available_services = self.client.services  # This freezes on Mac
                 eeg_service_available = False
                 for s in available_services:
                     if s.uuid == self.eeg_service_uuid:
@@ -298,8 +298,7 @@ class BLEClient(BTClient):
                 if not eeg_service_available:
                     self.try_disconnect.set()
                     self.read_event.set()
-                    if sys.platform != 'darwin':
-                        await self.client.unpair()
+                    await self.client.unpair()  # Not available on Mac
                     continue
 
             if self.try_disconnect.set():


### PR DESCRIPTION
- Removed reconnection counter / trying to reconnect multiple times (based on Maziar's request)
- Added a step to check for services offered by the bleak client and exit if the EEG service is not listed anymore (not on Mac)
- Also added unpairing (not on Mac)

This isn't tested on Linux and should be regarded as a hotfix for the issue, turning off the device, reconnecting, disconnecting all seems to work "as expected" now on Mac and Windows.