### PR TITLE
Froze pylsl version to 1.16.2 (for now)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ ext_modules_list = []
 current_platform = sys.platform
 
 if not os.environ.get('READTHEDOCS'):
-    my_req.append('pylsl')
+    my_req.append('pylsl==1.16.2')
     libPath = "lib"
     if current_platform == 'win32' or current_platform == 'win64':
         windows_lib_path = os.path.join(libPath, 'windows')


### PR DESCRIPTION
Freezes pylsl to 1.16.2, nothing more, nothing less (hopefully)