### PR TITLE
APIS-1191 Clear recorders after binary conversion

### DIFF
--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -371,9 +371,13 @@ class Explore:
                     progress_callback(int(progress * 100))
         finally:
             if self.recorders['file_type'] == 'csv':
+                self.stream_processor.unsubscribe(callback=self.recorders['marker'].set_marker, topic=TOPICS.marker)
                 self.recorders["marker"].stop()
+            self.stream_processor.unsubscribe(callback=self.recorders['exg'].write_data, topic=TOPICS.raw_ExG)
+            self.stream_processor.unsubscribe(callback=self.recorders['orn'].write_data, topic=TOPICS.raw_orn)
             self.recorders["exg"].stop()
             self.recorders["orn"].stop()
+            self.recorders = {}
             explorepy.set_bt_interface(bt_interface)
             logger.info('Conversion process terminated.')
 


### PR DESCRIPTION
Replaces the recorders of the Explore object with an empty dict after binary file conversion finishes.
This PR also unsubscribes them before replacing self.recorders, which isn't strictly necessary because the stream processor is replaced on connect anyway - but if we ever change behaviour, this would be marginally safer?