### PR TITLE
Put False into result queue on connection error

### DIFF
--- a/src/explorepy/BLEClient.py
+++ b/src/explorepy/BLEClient.py
@@ -189,16 +189,13 @@ class BLEClient(BTClient):
     def disconnect(self):
         """Disconnect from the device"""
         self.is_connected = False
-        try:
-            self.notify_task.cancel()
-            self.read_event.set()
-            time.sleep(1)
-            self.stop_read_loop()
-            self.ble_device = None
-            self.buffer = Queue()
-            logger.info('ExplorePy disconnecting from device')
-        except Exception:
-            pass
+        self.notify_task.cancel()
+        self.read_event.set()
+        time.sleep(1)
+        self.stop_read_loop()
+        self.ble_device = None
+        self.buffer = Queue()
+        logger.info('ExplorePy disconnecting from device')
 
     def _find_mac_address(self):
         raise NotImplementedError

--- a/src/explorepy/BLEClient.py
+++ b/src/explorepy/BLEClient.py
@@ -3,7 +3,6 @@ import atexit
 import logging
 import threading
 import time
-from doctest import UnexpectedException
 from queue import (
     Empty,
     Queue
@@ -111,7 +110,7 @@ class BLEClient(BTClient):
         self.notification_thread.start()
         print('waiting for BLE device to show up..')
         ret = self.result_queue.get()
-        if ret == False:
+        if not ret:
             logger.error("Got exception in read loop")
             raise UnexpectedConnectionError("Could not connect to the device")
 

--- a/src/explorepy/_exceptions.py
+++ b/src/explorepy/_exceptions.py
@@ -5,6 +5,7 @@ Customized exceptions module
 """
 import sys
 
+
 class UnexpectedConnectionError(ConnectionError):
     """
     Generic exception thrown if an unexpected error occurs during connection

--- a/src/explorepy/_exceptions.py
+++ b/src/explorepy/_exceptions.py
@@ -5,6 +5,12 @@ Customized exceptions module
 """
 import sys
 
+class UnexpectedConnectionError(ConnectionError):
+    """
+    Generic exception thrown if an unexpected error occurs during connection
+    """
+    pass
+
 
 class InputError(Exception):
     """


### PR DESCRIPTION
Issues on connect should now be propagated properly. result_queue.get() was blocking the execution of the connect method before.