### PR TITLE
Handle AttributeError when stream interface is None

### DIFF
--- a/src/explorepy/parser.py
+++ b/src/explorepy/parser.py
@@ -204,6 +204,10 @@ class Parser:
             except EOFError:
                 logger.info('End of file')
                 self.stop_streaming()
+            except AttributeError:
+                if self.stream_interface is None:
+                    # device already disconnected
+                    pass
             except Exception as error:
                 logger.critical('Unexpected error: ', error)
                 self.stop_streaming()


### PR DESCRIPTION
Added a specific exception handler for AttributeError in the streaming loop to gracefully handle cases where the stream interface is already disconnected.