### PR TITLE
Asr testing

### DIFF
--- a/src/explorepy/asr_processor.py
+++ b/src/explorepy/asr_processor.py
@@ -200,6 +200,7 @@ class AsrProcessor:
             self.last_clean_at = time.time()
         if not self.calibration_data_available:
             logger.warning("Attempting to clean data with no calibration available - returning...")
+            return
         new_data = np.array(packet.get_data()[1])
         new_ts = np.array(packet.get_data()[0])
         self.to_clean[:, :new_data.shape[1]] = new_data
@@ -277,12 +278,13 @@ class AsrProcessor:
     def set_state_from_calibration_data(self, calib_data):
         self.lifecycle_state = State.CLEANING
         cleaned, state = clean_calib_data(calib_data, self.sr)
-        self.lifecycle_state = state
         if cleaned is None:
             self.calibration_data_available = False
+            self.lifecycle_state = state
             return
         try:
             self._state = asr_calibrate(cleaned, self.sr, cutoff=self._cutoff)
+            self.lifecycle_state = state
         except np.linalg.LinAlgError as e:
             self.calibration_data_available = False
             self.lifecycle_state = State.CALIBRATION_ERROR

--- a/src/explorepy/asr_processor.py
+++ b/src/explorepy/asr_processor.py
@@ -281,4 +281,9 @@ class AsrProcessor:
         if cleaned is None:
             self.calibration_data_available = False
             return
-        self._state = asr_calibrate(cleaned, self.sr, cutoff=self._cutoff)
+        try:
+            self._state = asr_calibrate(cleaned, self.sr, cutoff=self._cutoff)
+        except np.linalg.LinAlgError as e:
+            self.calibration_data_available = False
+            self.lifecycle_state = State.CALIBRATION_ERROR
+            logger.error(f"Could not calibrate ASR: {e}")


### PR DESCRIPTION
This PR...

- adds returning early from cleaning data with ASR if no calibration data is available
- moves setting the lifecycle state in the asr processor to the different branches in set_state_from_calibration_data instead of after calling clean_calib_data (to avoid the state being reported as "STABLE" before the asr_calibrate step fails)
- catches a LinAlgError in case the asr_calibrate step fails