### PR TITLE
Prevent ASR while impedance mode is active

### DIFF
--- a/src/explorepy/_exceptions.py
+++ b/src/explorepy/_exceptions.py
@@ -62,6 +62,16 @@ class BleDisconnectionFailedError(Exception):
     pass
 
 
+class ImpedanceModeActiveError(Exception):
+    """
+    Exception for ASR, raised when impedance is running
+    """
+
+    def __init__(self, message="ASR can not run because impedance mode is active.\n"
+                               "Please disable impedance and try again\n"):
+        super().__init__(message)
+
+
 class ExplorePyDeprecationError(Exception):
     def __init__(self, message="Explorepy support for legacy devices is deprecated.\n"
                                "Please install explorepy 3.2.1 from Github or use the following command from Anaconda "

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -734,7 +734,7 @@ class Explore:
         return SettingsManager(self.device_name).get_adc_mask()
 
     def is_asr_processor_available(self):
-        return self.stream_processor.is_asr_processor_available()
+        return self.stream_processor.ensure_asr_processor_available()
 
     def calibrate_asr(self, length=-1.0):
         if self.is_asr_processor_available():

--- a/src/explorepy/explore.py
+++ b/src/explorepy/explore.py
@@ -734,7 +734,7 @@ class Explore:
         return SettingsManager(self.device_name).get_adc_mask()
 
     def is_asr_processor_available(self):
-        return self.stream_processor.asr_processor is not None and self.stream_processor.asr_processor.is_initialized
+        return self.stream_processor.is_asr_processor_available()
 
     def calibrate_asr(self, length=-1.0):
         if self.is_asr_processor_available():

--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -15,6 +15,7 @@ from typing import (
 
 import numpy as np
 
+from explorepy._exceptions import ImpedanceModeActiveError
 from explorepy.asr_processor import AsrProcessor
 from explorepy.command import (
     DeviceConfiguration,
@@ -619,3 +620,8 @@ class StreamProcessor:
         )
 
         return match.cutoff_freq if match else None
+
+    def is_asr_processor_available(self):
+        if self.is_imp_running():
+            raise ImpedanceModeActiveError()
+        return self.asr_processor is not None and self.asr_processor.is_initialized

--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -621,7 +621,7 @@ class StreamProcessor:
 
         return match.cutoff_freq if match else None
 
-    def is_asr_processor_available(self):
+    def ensure_asr_processor_available(self):
         if self.is_imp_running():
             raise ImpedanceModeActiveError()
         return self.asr_processor is not None and self.asr_processor.is_initialized


### PR DESCRIPTION
Add ImpedanceModeActiveError and guard ASR availability when impedance is running. StreamProcessor gains is_asr_processor_available() which raises ImpedanceModeActiveError if impedance mode is active and otherwise checks the ASR processor initialization. Explore.is_asr_processor_available() now delegates to the stream processor. Also add the new exception import.