### PR TITLE
Added exg_fs argument to get_data for CleanEEG

### DIFF
--- a/src/explorepy/packet.py
+++ b/src/explorepy/packet.py
@@ -184,7 +184,7 @@ class CleanEEG(Packet):
     def _convert(self, bin_data):
         self.data = bin_data
 
-    def get_data(self):
+    def get_data(self, exg_fs=None):
         return self.timestamps, self.data
 
     def __str__(self):


### PR DESCRIPTION
More proper solution would be to make CleanEEG an EEG packet, but this should also mean refactoring the EEG class imo, so this is shorter / easier.