### PR TITLE
Set imp_calculator to None on disable_imp

### DIFF
--- a/src/explorepy/stream_processor.py
+++ b/src/explorepy/stream_processor.py
@@ -483,6 +483,7 @@ class StreamProcessor:
         cmd = ZMeasurementDisable()
         if self.configure_device(cmd):
             self._is_imp_mode = False
+            self.imp_calculator = None
             print("Impedance measurement mode has been disabled.")
             return True
         print("WARNING: Couldn't disable impedance measurement mode. "


### PR DESCRIPTION
Sets imp_calculator to None when imp measurement is disabled. This fixes the stream processor not making and dispatching ASR packets (CleanEEG)