### PR TITLE
Clarify supported Python versions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Authors
 * Mohamad Atayi
 * Masoome Fazelian
 * Alex Platt
+* Shreeya Ramesh - `shreeyaashwini@icloud.com <mailto:shreeyaashwini@icloud.com>`_ - `GitHub <https://github.com/shreeyahi>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 
 Changelog
 =========
+Unreleased
+----------
+* Clarify supported Python versions and align the macOS conda setup with Python 3.12.
+
 4.5.1 (11.6.2025)
 ------------------
 * Hotfix LSL metadata

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 Minimal Requirements
 --------------------
-* Python 3.12 and upwards. We recommend using Python 3.12.
+* Python 3.10 to Python 3.12. We recommend using Python 3.12.
 * Microsoft Build Tools for Visual Studio 2019 (only Windows)
 * 6GB RAM (minimum 1GB *free* RAM during the session)
 * Intel i5 or higher (2x2.5GHz) CPU
@@ -120,7 +120,7 @@ Mac
 3. It is best to install Anaconda. Download  and run the `Anaconda installer for Mac <https://www.anaconda.com/download/success>`_. For older versions of MacOS, compatible version of Anaconda can be found in `this table <https://docs.continuum.io/anaconda/install/#old-os>`_ and downloaded `here <https://repo.anaconda.com/archive/index.html>`_.
 4. We recommend using a conda environment.
 
-   a. In the Anaconda command prompt: ``conda create -n myenv python=3.10``
+   a. In the Anaconda command prompt: ``conda create -n myenv python=3.12``
    b. Activate the conda environment: ``conda activate myenv``
 
 5. Upgrade your pip: ``python -m pip install --upgrade pip``


### PR DESCRIPTION
## Summary
- Clarify that supported Python versions are 3.10 through 3.12.
- Use Python 3.12 consistently in the macOS conda setup.
- Add the required changelog and contributor-credit entries.

## Why
The installation guide implied support for Python 3.13+, while README.rst and pyproject.toml list Python 3.10–3.12. The macOS example also used Python 3.10 despite recommending Python 3.12.

## Validation
- Ran `git diff --check` successfully.
- Compared the documentation with `README.rst` and `pyproject.toml`.
